### PR TITLE
Increase jetty-maven-plugin version to 7.5.3 due to bug fix in underlying jetty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.polopoly.jetty</groupId>
   <artifactId>jetty-maven-plugin</artifactId>
-  <version>7.4.5-polopoly-1.14-SNAPSHOT</version>
+  <version>7.5.3-polopoly-1.14-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <name>Jetty Maven Plugin with multi context support</name>
 
@@ -13,7 +13,7 @@
   <properties>
     <mavenVersion>3.0.3</mavenVersion>
     <pluginToolsVersion>2.5.1</pluginToolsVersion>
-    <jetty-version>7.4.5.v20110725</jetty-version>
+    <jetty-version>7.5.4.v20111024</jetty-version>
     <jsp-2-1-version>2.1.v20100127</jsp-2-1-version>
   </properties>
 


### PR DESCRIPTION
See https://jira.codehaus.org/browse/JETTY-1417.

This is a reduced to the minimum changes copy of the pull request I sent before: https://github.com/polopoly/jetty-maven-plugin/pull/3